### PR TITLE
Don't override profiling settings injected by environment variables

### DIFF
--- a/sbt-datadog/src/main/scala/com/guizmaii/sbt/DatadogAPM.scala
+++ b/sbt-datadog/src/main/scala/com/guizmaii/sbt/DatadogAPM.scala
@@ -36,11 +36,11 @@ object DatadogAPM extends AutoPlugin {
     )
 
     lazy val datadogProfilingEnabled = settingKey[Boolean](
-      "Datadog Profiling. See https://docs.datadoghq.com/profiler/enabling/java/?tab=commandarguments. Default: 'true'. Deactivated if `datadogApmEnabled` is `false`"
+      "Datadog Profiling. See https://docs.datadoghq.com/profiler/enabling/java/?tab=commandarguments. Default: `DD_PROFILING_ENABLED` envvar value if present, 'true' otherwise. Deactivated if `datadogApmEnabled` is `false`"
     )
 
     lazy val datadogAllocationProfilingEnabled = settingKey[Boolean](
-      "Datadog Allocations Profiling. See https://docs.datadoghq.com/profiler/enabling/java/?tab=commandarguments. Default: 'true'. Deactivated if `datadogApmEnabled` is `false`"
+      "Datadog Allocations Profiling. See https://docs.datadoghq.com/profiler/enabling/java/?tab=commandarguments. Default: `DD_PROFILING_DIRECTALLOCATION_ENABLED` envvar value if present, 'true' otherwise. Deactivated if `datadogApmEnabled` is `false` or `datadogProfilingEnabled` is `false`"
     )
 
     lazy val datadogServiceName = settingKey[String](

--- a/sbt-datadog/src/main/scala/com/guizmaii/sbt/DatadogAPM.scala
+++ b/sbt-datadog/src/main/scala/com/guizmaii/sbt/DatadogAPM.scala
@@ -112,13 +112,18 @@ object DatadogAPM extends AutoPlugin {
                |  export __ENABLE_TRACES__=${datadogApmEnabled.value}
                |fi
                |if [ "$${__ENABLE_TRACES__}" == "true" ]; then
-               |  export __ENABLE_PROFILING__=${datadogProfilingEnabled.value}
+               |  if [ ! -z "$${DD_PROFILING_ENABLED}" ]; then
+               |    export __ENABLE_PROFILING__=$${DD_PROFILING_ENABLED}
+               |  else
+               |    export __ENABLE_PROFILING__=${datadogProfilingEnabled.value}
+               |  fi
+               |  if [ ! -z "$${DD_PROFILING_DIRECTALLOCATION_ENABLED}" ]; then
+               |    export __ENABLE_ALLOCATION_PROFILING__=$${DD_PROFILING_DIRECTALLOCATION_ENABLED}
+               |  else
+               |    export __ENABLE_ALLOCATION_PROFILING__=${datadogAllocationProfilingEnabled.value}
+               |  fi
                |else
                |  export __ENABLE_PROFILING__=false
-               |fi
-               |if [ "$${__ENABLE_TRACES__}" == "true" ]; then
-               |  export __ENABLE_ALLOCATION_PROFILING__=${datadogAllocationProfilingEnabled.value}
-               |else
                |  export __ENABLE_ALLOCATION_PROFILING__=false
                |fi
                |addJava "-Ddd.trace.enabled=$${__ENABLE_TRACES__}"

--- a/sbt-datadog/src/main/scala/com/guizmaii/sbt/DatadogAPM.scala
+++ b/sbt-datadog/src/main/scala/com/guizmaii/sbt/DatadogAPM.scala
@@ -117,13 +117,16 @@ object DatadogAPM extends AutoPlugin {
                |  else
                |    export __ENABLE_PROFILING__=${datadogProfilingEnabled.value}
                |  fi
+               |else
+               |  export __ENABLE_PROFILING__=false
+               |fi
+               |if [ "$${__ENABLE_PROFILING__}" == "true" ]; then
                |  if [ ! -z "$${DD_PROFILING_DIRECTALLOCATION_ENABLED}" ]; then
                |    export __ENABLE_ALLOCATION_PROFILING__=$${DD_PROFILING_DIRECTALLOCATION_ENABLED}
                |  else
                |    export __ENABLE_ALLOCATION_PROFILING__=${datadogAllocationProfilingEnabled.value}
                |  fi
                |else
-               |  export __ENABLE_PROFILING__=false
                |  export __ENABLE_ALLOCATION_PROFILING__=false
                |fi
                |addJava "-Ddd.trace.enabled=$${__ENABLE_TRACES__}"


### PR DESCRIPTION
Scratching my own itch, noticed we stopped getting some profiling despite having the environment variables set.  Or was enabled when we disabled it in our deployment (via env). Hopefully should be straight foward.